### PR TITLE
Update script hook to restart properly + Adds feature to automatically run `npm install` after push

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In case you want to restart your app after deploy, you need to fill:
 - `RESTART`: a boolean to enable restart (default to `false`)
 - `API_KEY`: your api key you can find in your _profile_ section
 - `ACCOUNT`: the account name your site is associated to
+- `PASSWORD`: the account password your site is associated to
 - `SITE_ID`: the reference ID of your site you can find in your _sites_ section
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In case you want to restart your app after deploy, you need to fill:
 - `ACCOUNT`: the account name your site is associated to
 - `PASSWORD`: the account password your site is associated to
 - `SITE_ID`: the reference ID of your site you can find in your _sites_ section
-
+- `NPM_INSTALL_CHECK`: a boolean to enable if your site is a _Node.js_ site, and if you want to automatically run `npm install` if your package.json changed since the last push (default to `false`)
 
 ## Use
 

--- a/post-receive
+++ b/post-receive
@@ -11,6 +11,27 @@ API_KEY=""              # your api key you can find in your *profile* section
 ACCOUNT=""              # the account name your site is associated to
 PASSWORD=""             # the account password your site is associated to
 SITE_ID="000000"        # the reference ID of your site you can find in your *sites* section
+NPM_INSTALL_CHECK=false # a boolean to enable if your site is a _Node.js_ site, and if you want to automatically run `npm install` if your package.json changed since the last push (default to `false`)
+
+# Function checking if the "package.json" file has been changed since last push
+# MIT © Sindre Sorhus - sindresorhus.com / Adapted by J.M. Cléry for Alwaysdata
+npm_install_check() {
+	# git hook to run a command after `git push` if a specified file was changed
+	changed_files="$(git diff --name-only HEAD^ HEAD)"
+
+	check_run() {
+		if [ $(echo "$changed_files" | grep "$1") ]; then
+			cd $TARGET
+			echo "'package.json' has been updated! Running 'npm install' automatically for you..."
+			eval "$2"
+			cd $GIT_DIR
+		fi
+	}
+
+	# Run `npm install` ONLY if "package.json" has changed
+	# check_run package.json "npm install --silent --no-audit --no-progress > /dev/null"
+	check_run package.json "npm install > /dev/null"
+}
 
 ###
 # DO NOT EDIT BELOW UNLESS YOU KNOW WHAT YOU'RE DOING
@@ -27,6 +48,11 @@ while read oldrev newrev ref; do
 
 		echo "Deploying '${BRANCH}' branch to production"
 		git --work-tree=$TARGET --git-dir=$GIT_DIR checkout --force $BRANCH
+
+		# If it's a Node.js website and `npm install` needs to be trigerred
+		if [ $NPM_INSTALL_CHECK = true ]; then
+			npm_install_check
+		fi
 
 		if [ "$RESTART" = true ]; then
 			echo "Restarting your web server ..."

--- a/post-receive
+++ b/post-receive
@@ -2,26 +2,25 @@
 ###
 # CONFIG VARS
 ###
-TARGET="/home/madslab/net.madslab/test"
-GIT_DIR="/home/madslab/data/test-deploy.git"
-BRANCH="production"
-RESTART=false
-API_KEY=""
-ACCOUNT=""
-SITE_ID=000000
+TARGET="/home/madslab/net.madslab/test"      # the directory where the files need to be deployed
+GIT_DIR="/home/madslab/data/test-deploy.git" # the current git bare repository path
+BRANCH="production"                          # the branch to deploy (default to `production`)
+# In case you want to restart your app after deploy, you need to fill:
+RESTART=false           # a boolean to enable restart (default to `false`)
+API_KEY=""              # your api key you can find in your *profile* section
+ACCOUNT=""              # the account name your site is associated to
+PASSWORD=""             # the account password your site is associated to
+SITE_ID="000000"        # the reference ID of your site you can find in your *sites* section
 
 ###
 # DO NOT EDIT BELOW UNLESS YOU KNOW WHAT YOU'RE DOING
 ###
-while read oldrev newrev ref
-do
+while read oldrev newrev ref; do
 	# only checking out the branch to deploy
-	if [[ $ref = refs/heads/$BRANCH ]];
-	then
+	if [[ $ref = refs/heads/$BRANCH ]]; then
 		echo "Ref '$ref' received."
 
-		if [ ! -d "$TARGET" ];
-		then
+		if [ ! -d "$TARGET" ]; then
 			echo "'${TARGET}' dir is missing, creating it"
 			mkdir -p $TARGET
 		fi
@@ -29,22 +28,23 @@ do
 		echo "Deploying '${BRANCH}' branch to production"
 		git --work-tree=$TARGET --git-dir=$GIT_DIR checkout --force $BRANCH
 
-		if [ "$RESTART" = true ];
-		then
-			echo "Restarting your web server"
-			status=$(curl --basic --user "${API_KEY} account=${ACCOUNT}:" --data '' --request POST --silent --output /dev/null --write-out '%{http_code}' "https://api.alwaysdata.com/v1/site/${SITE_ID}/restart/")
-			if [ "$status" = 204 ];
-			then
-				echo "Your site is restarted"
+		if [ "$RESTART" = true ]; then
+			echo "Restarting your web server ..."
+
+			encoded_token=$(echo "$API_KEY account=$ACCOUNT:$PASSWORD" | base64 -w 0)
+			status=$(curl --location --request POST "https://api.alwaysdata.com/v1/site/${SITE_ID}/restart/" --header "Authorization: Basic $encoded_token" --write-out '%{http_code}' --silent)
+
+			if [ "$status" = 204 ]; then
+				echo "✅ Site successfully restarted!"
 			else
-				echo "An error occured when restarting your site, try to restart it manually"
+				echo "❌ An error occured when restarting your site, try to restart it manually"
 				exit 1
 			fi
 		fi
 
 		exit 0
 	else
-		echo "You pushed '$ref' branch,"
+		echo "🙄 You pushed '$ref' branch,"
 		echo "but you set '${BRANCH}' branch as deploy branch."
 		echo "Exiting without error."
 


### PR DESCRIPTION
As the password is also needed to POST to /restart/ , and as some passwords can contain special characters, I've edited the script hook to encode the Bearer token in base64.

Also, if the website is a Node.js website, it can be necessary sometimes to automatically re-run the `npm install` command on the server. A new feature gives the possibility to check if the 'package.json' has been updated, and run the `npm install` command.